### PR TITLE
Clean up typing and make it compatible with both CJS and ESM

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
 		'<rootDir>/src'
 	],
 	transform: {
-		'^.+\\.tsx?$': 'ts-jest'
+		'^.+\\.tsx?$': ['ts-jest', { useESM: true }]
 	},
 	verbose: true,
 	testEnvironment: 'node'

--- a/package.json
+++ b/package.json
@@ -50,5 +50,12 @@
     "onchange": "^7.1.0",
     "ts-jest": "^29.1.2",
     "typescript": "^5.4.2"
-  }
+  },
+  "exports": {
+    ".": {
+      "import": "./lib/index.mjs",
+      "require": "./lib/index.js"
+    }
+  },
+  "type": "module"
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,9 @@
 		"noUnusedLocals": true,
 		"pretty": true,
 		"strict": true, // includes noImplicitAny, noImplicitThis, alwaysStrict and all strict options
-		"outDir": "lib"
+		"outDir": "lib",
+		"module": "ESNext",
+		"moduleResolution": "node"
 	},
 	"include": [
 		"src/**/*"


### PR DESCRIPTION
Update `tsconfig.json`, `package.json`, and `jest.config.js` for ESM compatibility.

* **`tsconfig.json`**
  - Add `"module": "ESNext"` to `compilerOptions`.
  - Add `"moduleResolution": "node"` to `compilerOptions`.

* **`package.json`**
  - Add `"exports": { ".": { "import": "./lib/index.mjs", "require": "./lib/index.js" } }`.
  - Add `"type": "module"`.

* **`jest.config.js`**
  - Add `"transform": { "^.+\\.tsx?$": ["ts-jest", { "useESM": true }] }`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jpwilliams/waitgroup/pull/141?shareId=54df00c7-9434-484a-ba2e-b346d293d1a0).